### PR TITLE
Add ng-cloak on styling sheet

### DIFF
--- a/src/WoMoCo/wwwroot/css/site.css
+++ b/src/WoMoCo/wwwroot/css/site.css
@@ -1,3 +1,8 @@
+
+[ng\:cloak], [ng-cloak], [data-ng-cloak], [x-ng-cloak], .ng-cloak, .x-ng-cloak {
+  display: none !important;
+}
+
 body, html {
     height: 100%;
 }


### PR DESCRIPTION
Allow angular.js to be loaded in body, hiding cloaked elements until
templates compile.