### PR TITLE
Fixing bug where calender events in the morning fail

### DIFF
--- a/src/WoMoCo/wwwroot/ngApp/services/utilities.ts
+++ b/src/WoMoCo/wwwroot/ngApp/services/utilities.ts
@@ -1,16 +1,36 @@
 ﻿namespace WoMoCo.Services {
     export class UtilitiesService {
         public combineEventDateTime(dateToUse, timeToUse) {
-            let test = dateToUse.getFullYear() + "-" + (dateToUse.getMonth()+1) + "-" + dateToUse.getDate() + "T";
-            test += timeToUse.getHours() + ":";
-            if (timeToUse.getMinutes() == "0" || timeToUse.getMinutes() == "00") {
-                test += "00"
+            //let test = dateToUse.getFullYear() + "-" + (dateToUse.getMonth()+1) + "-" + dateToUse.getDate() + "T";
+            //test += timeToUse.getHours() + ":";
+            //if (timeToUse.getMinutes() == "0" || timeToUse.getMinutes() == "00") {
+            //    test += "00"
+            //} else {
+            //    test += timeToUse.getMinutes();
+            //}
+            //test += ":";
+            //if (timeToUse.getSeconds() == "0" || timeToUse.getSeconds() == "00") {
+            //    test += "00";
+            //} else {
+            //    test += timeToUse.getSeconds();
+            //}
+            //return test;
+            let test = dateToUse.getFullYear() + "-" + (dateToUse.getMonth() + 1) + "-" + dateToUse.getDate();
+            test += "T";
+            if (timeToUse.getHours() < 10) {
+                test += "0" + timeToUse.getHours(); // padding zero or it won't recognize AM
+            } else {
+                test += timeToUse.getHours();
+            }
+            test += ":";
+            if (timeToUse.getMinutes() == 0) {
+                test += "00"; // padding zero or it will break
             } else {
                 test += timeToUse.getMinutes();
             }
             test += ":";
-            if (timeToUse.getSeconds() == "0" || timeToUse.getSeconds() == "00") {
-                test += "00";
+            if (timeToUse.getSeconds() == 0) {
+                test += "00"; // padding zero or it will break
             } else {
                 test += timeToUse.getSeconds();
             }


### PR DESCRIPTION
I needed to add padding to events earlier than 10am so that the date object was formatted properly.